### PR TITLE
Docker: Revert to binary wheels for now due to build size and runtime

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN set -x \
         && \
     hash pip3 \
         && \
-    pip3 install --user --no-binary :all: --require-hashes -r requirements.txt \
+    pip3 install --user --require-hashes -r requirements.txt \
         && \
     pip3 check \
         && \


### PR DESCRIPTION
This reverts commit 69a475cc03783e434fc2cf135ab23b13c45f9ed8.

Related to #1735